### PR TITLE
Add Z3 to CI pipeline.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,34 +38,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: x86_64
-          manylinux: auto
-          container: off
-          args: --release --out target/dist
-      - name: Upload wheels
-        uses: actions/upload-artifact@v2
-        with:
-          name: wheels
-          path: target/dist
-
-  windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Z3.
-        id: z3
-        uses: cda-tum/setup-z3@v1
-        with:
-          version: 4.11.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-          architecture: x64
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: PyO3/maturin-action@v1
-        with:
-          target: x64
+          manylinux: auto          
           args: --release --out target/dist
       - name: Upload wheels
         uses: actions/upload-artifact@v2
@@ -76,19 +49,22 @@ jobs:
   macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout.
+        uses: actions/checkout@v3
       - name: Setup Z3.
         id: z3
         uses: cda-tum/setup-z3@v1
         with:
-          version: 4.11.2
+          version: ${{ env.Z3_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain.
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}
+      - run: echo "CPATH=$Z3_ROOT/include" >> $GITHUB_ENV
       - uses: PyO3/maturin-action@v1
         with:
           command: build
@@ -98,49 +74,4 @@ jobs:
         with:
           name: wheels
           path: target/dist
-
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [ macos, windows, linux ]
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: wheels
-      - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        with:
-          command: upload
-          args: --skip-existing *
-
-  conda_deployment_with_new_tag:
-    name: Conda deployment (${{ matrix.os }})
-    if: "startsWith(github.ref, 'refs/tags/')"
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # For now, windows builds are broken...
-        os: [macos-latest, ubuntu-latest]
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Conda environment creation and activation
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          python-version: 3.9
-          environment-file: conda_env.yaml
-          auto-update-conda: false
-          auto-activate-base: false
-          show-channel-urls: true
-      - name: Build and upload the conda packages
-        uses: uibcdf/action-build-and-upload-conda-packages@v1.1-beta.1
-        with:
-          python-version: 3.9
-          meta_yaml_dir: "conda"
-          user: daemontus
-          label: main
-          overwrite: false
-          token: ${{ secrets.ANACONDA_TOKEN }}
+  

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,10 @@ env:
   # Make sure to update this from time to time.
   RUST_VERSION: "1.65.0"
   # This is the version currently used by `z3-sys`.
-  # If this even changes, you might also need to increase
-  # minimum macOS version below.
+  # If this ever changes, you might also need to increase
+  # the minimum macOS version below.
   Z3_VERSION: "4.8.12"
+  MACOS_TARGET: "10.16"
   PYTHON_VERSION: "3.9"
 jobs:
   linux:
@@ -78,8 +79,9 @@ jobs:
       - run: echo "CPATH=$Z3_ROOT/include" >> $GITHUB_ENV
       # The considered version of z3 needs at least this version of macOS.
       # If you update z3-sys, you might need to increase this as well.
-      - run: echo "MACOSX_DEPLOYMENT_TARGET=10.16" >> $GITHUB_ENV
-      - uses: PyO3/maturin-action@v1
+      - run: echo "MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV
+      - name: Maturin build.
+        uses: PyO3/maturin-action@v1
         with:
           command: build
           args: "--release --universal2 --features static-z3 --out='target/dist'"
@@ -88,4 +90,79 @@ jobs:
         with:
           name: wheels
           path: target/dist
-  
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout.
+        uses: actions/checkout@v3
+      - name: Setup Z3.
+        id: z3
+        uses: cda-tum/setup-z3@v1
+        with:
+          version: ${{ env.Z3_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Python.
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          architecture: x64
+      - name: Setup Rust toolchain.
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}      
+      - name: Maturin build.
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x64
+          args: "--release --features static-z3 --out='target/dist'"
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: target/dist
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [ macos, windows, linux ]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: wheels
+      - name: Publish to PyPI
+        uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        with:
+          command: upload
+          args: --skip-existing *
+
+  conda_deployment_with_new_tag:
+    name: Conda deployment (${{ matrix.os }})
+    if: "startsWith(github.ref, 'refs/tags/')"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # For now, windows builds are broken...
+        os: [macos-latest, ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Conda environment creation and activation
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          environment-file: conda_env.yaml
+          auto-update-conda: false
+          auto-activate-base: false
+          show-channel-urls: true
+      - name: Build and upload the conda packages
+        uses: uibcdf/action-build-and-upload-conda-packages@v1.1-beta.1
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          meta_yaml_dir: "conda"
+          user: daemontus
+          label: main
+          overwrite: false
+          token: ${{ secrets.ANACONDA_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           target: x86_64
           manylinux: auto
           container: off          
-          args: --release --cargo-extra-args=\"--features static-z3\" --out=\"target/dist\"
+          args: "--release --cargo-extra-args=\"--features static-z3\" --out=\"target/dist\""
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -82,7 +82,7 @@ jobs:
       - uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --universal2 --cargo-extra-args=\"--features static-z3\" --out=\"target/dist\"
+          args: "--release --universal2 --cargo-extra-args=\"--features static-z3\" --out=\"target/dist\""
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,17 @@ jobs:
           architecture: x64
       - name: Install Rust toolchain.
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}
+      - name: Set up Clang
+        uses: egor-tensin/setup-clang@v1
+        with:
+          version: 13
+          platform: x64        
       - name: Maturin build.
         uses: PyO3/maturin-action@v1
         with:
           target: x86_64
           manylinux: auto
+          container: off
           args: --release --out target/dist
       - name: Upload wheels
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}
       # Explicitly add z3 to include path (probably some setup-z3 bug).
       - run: echo "CPATH=$Z3_ROOT/include" >> $GITHUB_ENV
+      - run: echo "LD_LIBRARY_PATH=$Z3_ROOT/lib" >> $GITHUB_ENV
       # The considered version of z3 needs at least this version of macOS.
       # If you update z3-sys, you might need to increase this as well.
       #- run: echo "MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV      

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,24 +2,35 @@ name: build
 on:
   push:
   pull_request:
-
+env:
+  # A fixed version used for testing, so that the builds don't
+  # spontaneously break after a few years.
+  # Make sure to update this from time to time.
+  RUST_VERSION: "1.65.0"
+  Z3_VERSION: "4.11.2"
+  PYTHON_VERSION: "3.9"
 jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout.
+        uses: actions/checkout@v3
       - name: Setup Z3.
         id: z3
         uses: cda-tum/setup-z3@v1
         with:
-          version: 4.11.2
+          version: ${{ env.Z3_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-python@v4
+      - name: Install Python.
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
-      - uses: PyO3/maturin-action@v1
+      - name: Install Rust toolchain.
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}
+      - name: Maturin build.
+        uses: PyO3/maturin-action@v1
         with:
           target: x86_64
           manylinux: auto

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,13 +78,14 @@ jobs:
       # Explicitly add z3 to include path (probably some setup-z3 bug).
       - run: echo "CPATH=$Z3_ROOT/include" >> $GITHUB_ENV      
       # The considered version of z3 needs at least this version of macOS.
-      - run: echo "MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV
+      #- run: echo "MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV
       - run: echo "CMAKE_OSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV
       - name: Maturin build.
         uses: PyO3/maturin-action@v1
         with:
-          command: build          
-          args: "--release --universal2 --features static-z3 --out='target/dist'"
+          command: build   
+          # --universal2       
+          args: "--release --features static-z3 --out='target/dist'"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,10 +47,9 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: x86_64
-          manylinux: auto
-          #container: off 
-          # --features static-z3 --compatibility manylinux_2_24         
-          args: "--release --out='target/dist'"
+          manylinux: 2_24
+          container: daemontus/manylinux-aeon:latest                   
+          args: "--release --features static-z3 --compatibility manylinux_2_24 --out='target/dist'"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           target: x86_64
           manylinux: auto
           container: off          
-          args: "--release --cargo-extra-args=\"--features static-z3\" --out=\"target/dist\""
+          args: "--release --cargo-extra-args='--features static-z3' --out='target/dist'"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -82,7 +82,7 @@ jobs:
       - uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: "--release --universal2 --cargo-extra-args=\"--features static-z3\" --out=\"target/dist\""
+          args: "--release --universal2 --cargo-extra-args='--features static-z3' --out='target/dist'"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Setup Rust toolchain.
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}
       # Seems that libclang is needed for z3 to work on linux?
-      #- name: Set up Clang
-      #  uses: egor-tensin/setup-clang@v1
-      #  with:
-      #    version: 13
-      #    platform: x64 
+      - name: Set up Clang
+        uses: egor-tensin/setup-clang@v1
+        with:
+          version: 13
+          platform: x64 
       # For now, we are building with container:off, because the
       # manylinux contrainer does not have the dependencies to 
       # build with Z3 enabled. We can later modify this and use
@@ -86,7 +86,8 @@ jobs:
         with:
           command: build
           # --features static-z3  -- -v -D MACOSX_DEPLOYMENT_TARGET=11.0
-          args: "--release --universal2  --out='target/dist'"
+          # --universal2
+          args: "--release --out='target/dist'"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
   # If this ever changes, you might also need to increase
   # the minimum macOS version below.
   Z3_VERSION: "4.8.12"
-  MACOS_TARGET: "10.16"
+  MACOS_TARGET: "11.0"
   PYTHON_VERSION: "3.9"
 jobs:
   linux:
@@ -49,7 +49,7 @@ jobs:
           target: x86_64
           manylinux: auto
           container: off          
-          args: "--release --features static-z3 --out='target/dist'"
+          args: "--release --features static-z3 --compatibility manylinux_2_24 --out='target/dist'"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -79,12 +79,12 @@ jobs:
       - run: echo "CPATH=$Z3_ROOT/include" >> $GITHUB_ENV
       # The considered version of z3 needs at least this version of macOS.
       # If you update z3-sys, you might need to increase this as well.
-      - run: echo "MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV
+      - run: echo "MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV      
       - name: Maturin build.
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: "--release --universal2 --features static-z3 --out='target/dist'"
+          args: "--release --universal2 --features static-z3 --out='target/dist' -DMACOSX_DEPLOYMENT_TARGET=11.0"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,8 +61,11 @@ jobs:
       - name: Maturin build.
         uses: PyO3/maturin-action@v1
         with:
-          command: build             
-          args: "--release --universal2 --features static-z3 --out='target/dist'"
+          command: build
+          # For now, universal builds are disabled, because there is something
+          # wrong with building z3 on arm in this way :/  
+          # --universal2           
+          args: "--release --features static-z3 --out='target/dist'"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -117,7 +120,7 @@ jobs:
     strategy:
       matrix:
         # For now, windows builds are broken...
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,10 @@ env:
   # spontaneously break after a few years.
   # Make sure to update this from time to time.
   RUST_VERSION: "1.65.0"
-  Z3_VERSION: "4.11.2"
+  # This is the version currently used by `z3-sys`.
+  # If this even changes, you might also need to increase
+  # minimum macOS version below.
+  Z3_VERSION: "4.8.12"
   PYTHON_VERSION: "3.9"
 jobs:
   linux:
@@ -22,12 +25,12 @@ jobs:
           version: ${{ env.Z3_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install Python.
+      - name: Setup Python.
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
-      - name: Install Rust toolchain.
+      - name: Setup Rust toolchain.
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}
       # Seems that libclang is needed for z3 to work on linux?
       - name: Set up Clang
@@ -45,7 +48,7 @@ jobs:
           target: x86_64
           manylinux: auto
           container: off          
-          args: --release --out target/dist
+          args: --release --cargo-extra-args="--features static-z3" --out="target/dist"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -64,17 +67,28 @@ jobs:
           version: ${{ env.Z3_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-python@v4
+      - name: Setup Python.
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
-      - name: Install Rust toolchain.
+      - name: Setup Rust toolchain.
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}
+      # Seems that libclang is needed for z3 to work on macos?
+      - name: Set up Clang
+        uses: egor-tensin/setup-clang@v1
+        with:
+          version: 13
+          platform: x64 
+      # Explicitly add z3 to include path (probably some setup-z3 bug).
       - run: echo "CPATH=$Z3_ROOT/include" >> $GITHUB_ENV
+      # The considered version of z3 needs at least this version of macOS.
+      # If you update z3-sys, you might need to increase this as well.
+      - run: echo "MACOSX_DEPLOYMENT_TARGET=10.16" >> $GITHUB_ENV
       - uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --out target/dist --universal2
+          args: --release --universal2 --cargo-extra-args="--features static-z3" --out="target/dist"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
       # Explicitly add z3 to include path (probably some setup-z3 bug).
       - run: echo "CPATH=$Z3_ROOT/include" >> $GITHUB_ENV      
       # The considered version of z3 needs at least this version of macOS.
-      # Interestingly, setting MACOSX_DEPLOYMENT_TARGET does not work, but this does.
+      - run: echo "MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV
       - run: echo "CMAKE_OSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV
       - name: Maturin build.
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: x86_64
-          manylinux: 2_24
+          #manylinux: 2_24
           container: daemontus/manylinux-aeon:latest                   
           args: "--release --features static-z3 --compatibility manylinux_2_24 --out='target/dist'"
       - name: Upload wheels
@@ -78,7 +78,7 @@ jobs:
       # Explicitly add z3 to include path (probably some setup-z3 bug).
       - run: echo "CPATH=$Z3_ROOT/include" >> $GITHUB_ENV      
       # The considered version of z3 needs at least this version of macOS.
-      #- run: echo "MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV
+      - run: echo "MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV
       - run: echo "CMAKE_OSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV
       - name: Maturin build.
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           target: x86_64
           #manylinux: 2_24
           container: daemontus/manylinux-aeon:latest                   
-          args: "--release --features static-z3 --compatibility manylinux_2_24 --out='target/dist'"
+          args: "--release --features static-z3 --compatibility manylinux_2_28 --out='target/dist'"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,35 +19,12 @@ jobs:
     steps:
       - name: Checkout.
         uses: actions/checkout@v3
-      - name: Setup Z3.
-        id: z3
-        uses: cda-tum/setup-z3@v1
-        with:
-          version: ${{ env.Z3_VERSION }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Python.
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          architecture: x64
-      - name: Setup Rust toolchain.
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}
-      # Seems that libclang is needed for z3 to work on linux?
-      - name: Set up Clang
-        uses: egor-tensin/setup-clang@v1
-        with:
-          version: 13
-          platform: x64 
-      # For now, we are building with container:off, because the
-      # manylinux contrainer does not have the dependencies to 
-      # build with Z3 enabled. We can later modify this and use
-      # our own fork of manylinux.
+      # On linux, everything is installed in the container,
+      # so we don't really need any dependencies here.
       - name: Maturin build.
         uses: PyO3/maturin-action@v1
         with:
           target: x86_64
-          #manylinux: 2_24
           container: daemontus/manylinux-aeon:latest                   
           args: "--release --features static-z3 --compatibility manylinux_2_28 --out='target/dist'"
       - name: Upload wheels
@@ -60,7 +37,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout.
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3      
       - name: Setup Z3.
         id: z3
         uses: cda-tum/setup-z3@v1
@@ -75,7 +52,8 @@ jobs:
           architecture: x64
       - name: Setup Rust toolchain.
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}
-      # Explicitly add z3 to include path (probably some setup-z3 bug).
+      # Explicitly add z3 to include path (probably some bug in either 
+      # `setup-z3` or `z3-sys` crate, because this should not be necessary).
       - run: echo "CPATH=$Z3_ROOT/include" >> $GITHUB_ENV      
       # The considered version of z3 needs at least this version of macOS.
       - run: echo "MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV
@@ -83,9 +61,8 @@ jobs:
       - name: Maturin build.
         uses: PyO3/maturin-action@v1
         with:
-          command: build   
-          # --universal2       
-          args: "--release --features static-z3 --out='target/dist'"
+          command: build             
+          args: "--release --universal2 --features static-z3 --out='target/dist'"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -97,13 +74,6 @@ jobs:
     steps:
       - name: Checkout.
         uses: actions/checkout@v3
-      - name: Setup Z3.
-        id: z3
-        uses: cda-tum/setup-z3@v1
-        with:
-          version: ${{ env.Z3_VERSION }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Python.
         uses: actions/setup-python@v4
         with:
@@ -111,6 +81,7 @@ jobs:
           architecture: x64
       - name: Setup Rust toolchain.
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}            
+      # Surprisingly, windows is the easiest. Just build the thing.
       - name: Maturin build.
         uses: PyO3/maturin-action@v1
         with:
@@ -141,12 +112,12 @@ jobs:
 
   conda_deployment_with_new_tag:
     name: Conda deployment (${{ matrix.os }})
-    if: "startsWith(github.ref, 'refs/tags/')"
+    #if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         # For now, windows builds are broken...
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,7 @@ jobs:
           architecture: x64
       - name: Setup Rust toolchain.
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}      
+      - run: echo "CPATH=$Z3_ROOT/include" >> $GITHUB_ENV        
       - name: Maturin build.
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
 
   conda_deployment_with_new_tag:
     name: Conda deployment (${{ matrix.os }})
-    #if: "startsWith(github.ref, 'refs/tags/')"
+    if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,19 +77,15 @@ jobs:
       - name: Setup Rust toolchain.
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}
       # Explicitly add z3 to include path (probably some setup-z3 bug).
-      - run: echo "CPATH=$Z3_ROOT/include" >> $GITHUB_ENV
-      - run: echo "LD_LIBRARY_PATH=$Z3_ROOT/lib" >> $GITHUB_ENV      
+      - run: echo "CPATH=$Z3_ROOT/include" >> $GITHUB_ENV      
       # The considered version of z3 needs at least this version of macOS.
-      # If you update z3-sys, you might need to increase this as well.
-      - run: echo "MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV      
+      # Interestingly, setting MACOSX_DEPLOYMENT_TARGET does not work, but this does.
       - run: echo "CMAKE_OSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV
       - name: Maturin build.
         uses: PyO3/maturin-action@v1
         with:
-          command: build
-          # --features static-z3  -- -v -D MACOSX_DEPLOYMENT_TARGET=11.0
-          # --universal2
-          args: "--release --features static-z3 --out='target/dist'"
+          command: build          
+          args: "--release --universal2 --features static-z3 --out='target/dist'"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -114,14 +110,12 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
       - name: Setup Rust toolchain.
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}      
-      - run: echo "CPATH=$Z3_ROOT/include" >> $GITHUB_ENV        
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}            
       - name: Maturin build.
         uses: PyO3/maturin-action@v1
         with:
           target: x64
-          # --features static-z3
-          args: "--release --out='target/dist'"
+          args: "--release --features static-z3 --out='target/dist'"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           target: x86_64
           manylinux: auto
           container: off          
-          args: "--release --cargo-extra-args='--features static-z3' --out='target/dist'"
+          args: "--release --features static-z3 --out='target/dist'"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -82,7 +82,7 @@ jobs:
       - uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: "--release --universal2 --cargo-extra-args='--features static-z3' --out='target/dist'"
+          args: "--release --universal2 --features static-z3 --out='target/dist'"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: "--release --universal2 --features static-z3 --out='target/dist' -DMACOSX_DEPLOYMENT_TARGET=11.0"
+          args: "--release --universal2 --features static-z3 --out='target/dist' -- -DMACOSX_DEPLOYMENT_TARGET=11.0"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Setup Rust toolchain.
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}
       # Seems that libclang is needed for z3 to work on linux?
-      - name: Set up Clang
-        uses: egor-tensin/setup-clang@v1
-        with:
-          version: 13
-          platform: x64 
+      #- name: Set up Clang
+      #  uses: egor-tensin/setup-clang@v1
+      #  with:
+      #    version: 13
+      #    platform: x64 
       # For now, we are building with container:off, because the
       # manylinux contrainer does not have the dependencies to 
       # build with Z3 enabled. We can later modify this and use
@@ -48,8 +48,9 @@ jobs:
         with:
           target: x86_64
           manylinux: auto
-          container: off          
-          args: "--release --features static-z3 --compatibility manylinux_2_24 --out='target/dist'"
+          #container: off 
+          # --features static-z3 --compatibility manylinux_2_24         
+          args: "--release --out='target/dist'"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -79,12 +80,13 @@ jobs:
       - run: echo "CPATH=$Z3_ROOT/include" >> $GITHUB_ENV
       # The considered version of z3 needs at least this version of macOS.
       # If you update z3-sys, you might need to increase this as well.
-      - run: echo "MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV      
+      #- run: echo "MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV      
       - name: Maturin build.
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: "--release --universal2 --features static-z3 --out='target/dist' -- -v -D MACOSX_DEPLOYMENT_TARGET=11.0"
+          # --features static-z3  -- -v -D MACOSX_DEPLOYMENT_TARGET=11.0
+          args: "--release --universal2  --out='target/dist'"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -114,7 +116,8 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: x64
-          args: "--release --features static-z3 --out='target/dist'"
+          # --features static-z3
+          args: "--release --out='target/dist'"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,17 +78,18 @@ jobs:
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}
       # Explicitly add z3 to include path (probably some setup-z3 bug).
       - run: echo "CPATH=$Z3_ROOT/include" >> $GITHUB_ENV
-      - run: echo "LD_LIBRARY_PATH=$Z3_ROOT/lib" >> $GITHUB_ENV
+      - run: echo "LD_LIBRARY_PATH=$Z3_ROOT/lib" >> $GITHUB_ENV      
       # The considered version of z3 needs at least this version of macOS.
       # If you update z3-sys, you might need to increase this as well.
-      #- run: echo "MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV      
+      - run: echo "MACOSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV      
+      - run: echo "CMAKE_OSX_DEPLOYMENT_TARGET=${{ env.MACOS_TARGET }}" >> $GITHUB_ENV
       - name: Maturin build.
         uses: PyO3/maturin-action@v1
         with:
           command: build
           # --features static-z3  -- -v -D MACOSX_DEPLOYMENT_TARGET=11.0
           # --universal2
-          args: "--release --out='target/dist'"
+          args: "--release --features static-z3 --out='target/dist'"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,16 +29,22 @@ jobs:
           architecture: x64
       - name: Install Rust toolchain.
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}
+      # Seems that libclang is needed for z3 to work on linux?
       - name: Set up Clang
         uses: egor-tensin/setup-clang@v1
         with:
           version: 13
-          platform: x64        
+          platform: x64 
+      # For now, we are building with container:off, because the
+      # manylinux contrainer does not have the dependencies to 
+      # build with Z3 enabled. We can later modify this and use
+      # our own fork of manylinux.
       - name: Maturin build.
         uses: PyO3/maturin-action@v1
         with:
           target: x86_64
-          manylinux: auto          
+          manylinux: auto
+          container: off          
           args: --release --out target/dist
       - name: Upload wheels
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           target: x86_64
           manylinux: auto
           container: off          
-          args: --release --cargo-extra-args="--features static-z3" --out="target/dist"
+          args: --release --cargo-extra-args=\"--features static-z3\" --out=\"target/dist\"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -74,12 +74,6 @@ jobs:
           architecture: x64
       - name: Setup Rust toolchain.
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ env.RUST_VERSION }}
-      # Seems that libclang is needed for z3 to work on macos?
-      - name: Set up Clang
-        uses: egor-tensin/setup-clang@v1
-        with:
-          version: 13
-          platform: x64 
       # Explicitly add z3 to include path (probably some setup-z3 bug).
       - run: echo "CPATH=$Z3_ROOT/include" >> $GITHUB_ENV
       # The considered version of z3 needs at least this version of macOS.
@@ -88,7 +82,7 @@ jobs:
       - uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --universal2 --cargo-extra-args="--features static-z3" --out="target/dist"
+          args: --release --universal2 --cargo-extra-args=\"--features static-z3\" --out=\"target/dist\"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: "--release --universal2 --features static-z3 --out='target/dist' -- -DMACOSX_DEPLOYMENT_TARGET=11.0"
+          args: "--release --universal2 --features static-z3 --out='target/dist' -- -v -D MACOSX_DEPLOYMENT_TARGET=11.0"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ pyo3 = { version = "0.17.3", features = ["abi3-py37", "extension-module"] }
 biodivine-lib-param-bn = "0.4.1"
 biodivine-lib-bdd = "0.4.2"
 biodivine-pbn-control = { git="https://github.com/sybila/biodivine-pbn-control", rev="1847a6290cadf964fecc9e75d6821907cc715109" }
-# z3 = { version="0.11.2", features = ["static-link-z3"] }
+z3 = { version="0.11.2", features = ["static-link-z3"] }
 
 [build-dependencies]
 pyo3-build-config = "0.17.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,24 @@ edition = "2021"
 name = "biodivine_aeon"
 crate-type = ["cdylib", "rlib"]
 
+[features]
+# For releases, we want to include Z3 statically, so that users
+# don't have to install it (or break compatibility with new versions).
+# So for CI builds, this feature is enabled, but for local builds,
+# you don't need it as long as you have Z3 installed (because your
+# build may take >30min if you enable it).
+static-z3 = ["z3/static-link-z3"]
+
 [dependencies]
 pyo3 = { version = "0.17.3", features = ["abi3-py37", "extension-module"] }
 biodivine-lib-param-bn = "0.4.1"
 biodivine-lib-bdd = "0.4.2"
 biodivine-pbn-control = { git="https://github.com/sybila/biodivine-pbn-control", rev="1847a6290cadf964fecc9e75d6821907cc715109" }
-z3 = { version="0.11.2", features = ["static-link-z3"] }
+
+# Include Z3 dependencies as strictly as possible, we don't want
+# this to change because it might break our release builds.
+z3="^0.11.2"
+z3-sys = "^0.7.1"
 
 [build-dependencies]
 pyo3-build-config = "0.17.3"

--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -1,3 +1,3 @@
-maturin build --release -o dist
+maturin build --release --features static-z3 -o dist
 dir dist
 pip install "dist/*.whl"

--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -1,3 +1,4 @@
+maturin list-python
 maturin build --release --features static-z3 -o dist
 dir dist
 pip install "dist/*.whl"

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -3,11 +3,11 @@
 set -ex
 
 if [ `uname` == Darwin ]; then
-  maturin build --release --interpreter python -o dist --universal2
+  maturin build --release --interpreter python -o dist --universal2 --features z3
 fi
 
 if [ `uname` == Linux ]; then
-  maturin build --release --interpreter python -o dist
+  maturin build --release --interpreter python -o dist --features z3
 fi
 
 pip install dist/*.whl --no-deps --ignore-installed

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -3,7 +3,8 @@
 set -ex
 
 if [ `uname` == Darwin ]; then
-  maturin build --release --interpreter python -o dist --universal2 --features static-z3
+  #  --universal2 (disabled for now)
+  maturin build --release --interpreter python -o dist --features static-z3
 fi
 
 if [ `uname` == Linux ]; then

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -2,10 +2,10 @@
 
 set -ex
 
-if [ `uname` == Darwin ]; then
-  #  --universal2 (disabled for now)
+if [ `uname` == Darwin ]; then  
   export MACOSX_DEPLOYMENT_TARGET="11.0"
   export CMAKE_OSX_DEPLOYMENT_TARGET="11.0"
+  #  --universal2 (disabled for now)
   maturin build --release --interpreter python -o dist --features static-z3
 fi
 

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -4,6 +4,8 @@ set -ex
 
 if [ `uname` == Darwin ]; then
   #  --universal2 (disabled for now)
+  export MACOSX_DEPLOYMENT_TARGET="11.0"
+  export CMAKE_OSX_DEPLOYMENT_TARGET="11.0"
   maturin build --release --interpreter python -o dist --features static-z3
 fi
 

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -3,11 +3,11 @@
 set -ex
 
 if [ `uname` == Darwin ]; then
-  maturin build --release --interpreter python -o dist --universal2 --features z3
+  maturin build --release --interpreter python -o dist --universal2 --features static-z3
 fi
 
 if [ `uname` == Linux ]; then
-  maturin build --release --interpreter python -o dist --features z3
+  maturin build --release --interpreter python -o dist --features static-z3
 fi
 
 pip install dist/*.whl --no-deps --ignore-installed

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "biodivine_aeon" %}
-{% set version = "0.2.0-alpha" %}
+{% set version = "0.2.0a0" %}
 
 package:
   name: "{{ name|lower }}"

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -14,12 +14,12 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - z3
   host:
     - pip
     - rust
     - maturin
-    - python
-    - z3
+    - python    
   run:
     - python
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -19,7 +19,6 @@ requirements:
     - rust
     - maturin
     - python    
-    - z3
   run:
     - python
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -13,13 +13,13 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
-    - z3
+    - {{ compiler('c') }}    
   host:
     - pip
     - rust
     - maturin
     - python    
+    - z3
   run:
     - python
 

--- a/manylinux-image/Dockerfile
+++ b/manylinux-image/Dockerfile
@@ -5,4 +5,5 @@
 # consult https://github.com/phusion/baseimage-docker
 FROM quay.io/pypa/manylinux_2_24_x86_64:latest
 
-RUN apt-get install --no-install-recommends clang z3
+RUN apt-get update
+RUN apt-get install --yes --no-install-recommends clang z3

--- a/manylinux-image/Dockerfile
+++ b/manylinux-image/Dockerfile
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+
+# We inherit from an ubuntu image that is modified to support long-running services
+# consisting of multiple processes. To learn how to define a background services, 
+# consult https://github.com/phusion/baseimage-docker
+FROM quay.io/pypa/manylinux_2_24_x86_64:latest
+
+RUN apt-get install --no-install-recommends clang z3

--- a/manylinux-image/Dockerfile
+++ b/manylinux-image/Dockerfile
@@ -3,7 +3,7 @@
 # We inherit from an ubuntu image that is modified to support long-running services
 # consisting of multiple processes. To learn how to define a background services, 
 # consult https://github.com/phusion/baseimage-docker
-FROM quay.io/pypa/manylinux_2_24_x86_64:latest
+FROM quay.io/pypa/manylinux_2_28_x86_64:latest
 
-RUN apt-get update
-RUN apt-get install --yes --no-install-recommends clang z3
+#RUN apt-get update
+RUN dnf install -y clang

--- a/manylinux-image/REAMDE.md
+++ b/manylinux-image/REAMDE.md
@@ -1,1 +1,10 @@
 Because we need `libclang` and `z3` during build, we can't use the default manylinux docker. Here, we define a docker image that derives from manylinux but actually has the dependencies to build Z3.
+
+To publish the docker image, run:
+
+```
+docker build -t daemontus/manylinux-aeon .
+docker push daemontus/manylinux-aeon
+```
+
+( If this is a new person maintaining this: use your own username and then change it in the CI script ;) )

--- a/manylinux-image/REAMDE.md
+++ b/manylinux-image/REAMDE.md
@@ -1,0 +1,1 @@
+Because we need `libclang` and `z3` during build, we can't use the default manylinux docker. Here, we define a docker image that derives from manylinux but actually has the dependencies to build Z3.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.13,<0.14"]
+requires = ["maturin>=0.14,<0.15"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
This PR adds the support to build the library with static Z3 included. (I did it in my own fork to avoid spamming the CI pipeline on the main repo)

Right now, both `pypi` and `conda` builds should work, but the windows conda issue is still not resolved. Unfortunately, we also lost the ability to build universal binaries for macOS. So anyone with ARM might be a bit sad. But hopefully we'll be able to restore this later on.